### PR TITLE
[기능 추가] 팀 초대 승락/거절 API 및 팀 초대 메세지 확인 API 구현

### DIFF
--- a/teams/views.py
+++ b/teams/views.py
@@ -71,7 +71,7 @@ class TeamInviteAPIView(APIView):
         
 
         data = {
-            "invite_message" : f"{team.name}팀에 초대되었습니다. from:{team.leader.username}"
+            "invite_message" : f"team:{team.name} | from:{team.leader.username}"
         }
 
         serializer = UserSerializer(invite_user_instance, data=data, partial=True)

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from users.views import SignupView, UserInviteAPIView
+from users.views import SignupView, UserInviteAPIView, UserInviteAcceptAPIView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenBlacklistView
 
 urlpatterns = [
@@ -10,5 +10,6 @@ urlpatterns = [
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('logout/', TokenBlacklistView.as_view(), name='token_blacklist'),
 
-    path('invite/accept/', UserInviteAPIView.as_view(), name='user-accept'),
+    path('invite/', UserInviteAPIView.as_view(), name='user-invite'),
+    path('invite/accept/', UserInviteAcceptAPIView.as_view(), name='user-accept'),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from users.views import SignupView, UserInviteAPIView, UserInviteAcceptAPIView
+from users.views import SignupView, UserInviteAPIView, UserInviteAcceptAPIView, UserInviteRefuseAPIView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenBlacklistView
 
 urlpatterns = [
@@ -12,4 +12,5 @@ urlpatterns = [
 
     path('invite/', UserInviteAPIView.as_view(), name='user-invite'),
     path('invite/accept/', UserInviteAcceptAPIView.as_view(), name='user-accept'),
+    path('invite/refuse/', UserInviteRefuseAPIView.as_view(), name='user-refuse'),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from users.views import SignupView
+from users.views import SignupView, UserInviteAPIView
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenBlacklistView
 
 urlpatterns = [
@@ -9,4 +9,6 @@ urlpatterns = [
     path('login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('logout/', TokenBlacklistView.as_view(), name='token_blacklist'),
+
+    path('invite/accept/', UserInviteAPIView.as_view(), name='user-accept'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -35,10 +35,26 @@ class SignupView(APIView):
             return Response(data, status=status.HTTP_201_CREATED)
         
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+
+
+# api/v1/users/invite/
+class UserInviteAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        user = request.user
+
+        if user.invite_message is None:
+            return Response({"message" : "초대받은 기록이 없습니다."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        team_name = user.invite_message.split("|")[0].split(":")[1]
+        leader = user.invite_message.split("|")[1].split(":")[1]
+
+        return Response({"message" : f"{leader}님이 {team_name}에 초대하셨습니다."}, status=status.HTTP_200_OK)
+
 
 # api/v1/users/invite/accept/
-class UserInviteAPIView(APIView):
+class UserInviteAcceptAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):

--- a/users/views.py
+++ b/users/views.py
@@ -79,3 +79,23 @@ class UserInviteAcceptAPIView(APIView):
         }
 
         return Response(data, status=status.HTTP_200_OK)
+    
+
+# api/v1/users/invite/refuse/
+class UserInviteRefuseAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        user = request.user
+        invite_message = user.invite_message
+
+        team_name = invite_message.split("|")[0].split(":")[1]
+
+        user.invite_message = None
+        user.save()
+
+        data = {
+            "messsage" : f"{team_name} 초대를 거절하셨습니다."
+        }
+
+        return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## 반영 브랜치
feature/teams/#5 -> develop

## 변경 사항
- 초대메세지를 받은 팀원은 초대 메세지를 확인할 수 있고, 팀 초대를 승락할 수 있다.
- 팀 초대를 거절 할 수 있다.

## 테스트 결과
### 팀 초대 메세지 확인
![image](https://github.com/kyeon06/project-management-system/assets/111492415/5995ddf4-0cd7-4352-ae58-e1d22826c524)
### 팀 초대 승락 API
![image](https://github.com/kyeon06/project-management-system/assets/111492415/ab401454-e7aa-40cf-9cc4-6c7d27d9368c)
### 팀원 초대 거절 API
![image](https://github.com/kyeon06/project-management-system/assets/111492415/f0503ef1-ee28-40e1-9777-dc9576640855)

